### PR TITLE
Update for post 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Here are some samples of what you could put in the file:
 
 ```
 apples:
-  id: 260
+  id: APPLE
   chance: .5
   rolls: 4
   amount: 3
 a_sword:
-  id: 267
+  id: IRON_SWORD
   chance: .3
   rolls: 1
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.dumptruckman.minecraft</groupId>
     <artifactId>ChestRestock</artifactId>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
     <name>ChestRestock</name>
     <description>Chest Restocking plugin</description>
     <properties>
@@ -182,15 +182,15 @@ and adjust the build number accordingly -->
         </plugins>
     </build>
     <dependencies>
-        <!-- Bukkit Dependency -->
+        <!-- Spigot Dependency -->
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.12-R0.1-SNAPSHOT</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.15-R0.1-SNAPSHOT</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>
-        <!-- Bukkit Dependency -->
+        <!-- Spigot Dependency -->
         <!-- Start of PluginBase Dependency -->
         <dependency>
             <groupId>com.dumptruckman.minecraft</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <description>Chest Restocking plugin</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.number>UNKNOWN</project.build.number>
+        <project.build.number>1</project.build.number>
     </properties>
 
     <repositories>

--- a/src/main/java/com/dumptruckman/chestrestock/DefaultLootConfig.java
+++ b/src/main/java/com/dumptruckman/chestrestock/DefaultLootConfig.java
@@ -35,14 +35,13 @@ class DefaultLootConfig implements LootConfig {
                 + nl + "chance - the chance at which the section will be picked (as a fraction: 0.25 == 25%).  default: 1"
                 + nl + "rolls - the number of times the section will be considered.  default: 1"
                 + nl + "split (true/false) - if true, chance will be used as section weight and only 1 section will be picked.  default: false"
-                + nl + "id - the item id (number).  default: none"
-                + nl + "data - the item data value (number).  default: none"
+                + nl + "id - the item id (See https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html for possibilities).  default: none"
+                + nl + "damage - the amount the item has been damaged. -1 for unbreakable item.  default: 0"
                 + nl + "amount - the amount of the item.  default: 1"
                 + nl + "==================="
                 + nl + "enchant - This indicates there is an enchantment for the item selected for this section.  The following values must be defined under enchant:"
-                + nl + "name - the name of the enchantment.  default: none.  (possible values: http://jd.bukkit.org/apidocs/org/bukkit/enchantments/Enchantment.html)"
+                + nl + "name - the name of the enchantment.  default: none.  (possible values: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/enchantments/Enchantment.html)"
                 + nl + "level - the level of the enchantment.  Negative values indicate random level from 1 to -level.  default: 1"
-                + nl + "safe - whether or not to only allow safe enchantments.  default: true.  This means only appropriate enchantment/level for the item."
                 + nl + "PLEASE NOTE: The enchant section can have all the normal properties but cannot indicate items.  This means, you can do random sets of enchants!"
                 + nl + "Refer to loot_example.yml for a complete example!");
         try {

--- a/src/main/java/com/dumptruckman/chestrestock/DefaultLootTable.java
+++ b/src/main/java/com/dumptruckman/chestrestock/DefaultLootTable.java
@@ -3,10 +3,14 @@ package com.dumptruckman.chestrestock;
 import com.dumptruckman.chestrestock.api.LootTable;
 import com.dumptruckman.chestrestock.api.LootTable.ItemSection;
 import com.dumptruckman.minecraft.pluginbase.util.Logging;
+
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -206,8 +210,8 @@ class DefaultLootTable implements LootTable, ItemSection {
         protected String name;
 
         // Related to items
-        protected int itemId = 0;
-        protected short itemData = 0;
+        protected String itemId = "AIR";
+        protected short itemDurability = -1;
         protected int itemAmount = 1;
 
         // Related to enchants
@@ -224,10 +228,10 @@ class DefaultLootTable implements LootTable, ItemSection {
             for (String key : section.getKeys(false)) {
                 if (key.equalsIgnoreCase("rolls")) {
                     rolls = section.getInt("rolls", 1);
+                } else if (key.equalsIgnoreCase("durability")) {
+                    itemDurability = (short) section.getInt("durability", -1);
                 } else if (key.equalsIgnoreCase("id")) {
-                    itemId = section.getInt("id", 0);
-                } else if (key.equalsIgnoreCase("data")) {
-                    itemData = (short) section.getInt("data", 0);
+                    itemId = section.getString("id", "AIR");
                 } else if (key.equalsIgnoreCase("amount")) {
                     itemAmount = (short) section.getInt("amount", 1);
                 } else if (key.equalsIgnoreCase("chance")) {
@@ -307,10 +311,21 @@ class DefaultLootTable implements LootTable, ItemSection {
 
         @Override
         public ItemStack getItem() {
-            if (itemId > 0 && itemAmount > 0 && itemData >= 0) {
-                return new ItemStack(itemId, itemAmount, itemData);
+        	Material item = Material.valueOf(itemId);
+            if (item != null && itemAmount > 0) {
+                ItemStack result = new ItemStack(item, itemAmount);
+                if(itemDurability != -1)
+                {
+                	ItemMeta meta = result.getItemMeta();
+                	if(meta instanceof Damageable)
+                	{
+                		((Damageable) meta).setDamage(itemDurability);
+                		result.setItemMeta(meta);
+                	}
+                }
+                return result;
             }
-            return null;
+            return new ItemStack(Material.AIR, 1);
         }
 
         @Override

--- a/src/main/java/com/dumptruckman/chestrestock/DefaultLootTable.java
+++ b/src/main/java/com/dumptruckman/chestrestock/DefaultLootTable.java
@@ -204,7 +204,7 @@ class DefaultLootTable implements LootTable, ItemSection {
 
         // Related to items
         protected String itemId = "AIR";
-        protected short itemDurability = -1;
+        protected short itemDamage = 0;
         protected int itemAmount = 1;
 
         // Related to enchants
@@ -221,7 +221,7 @@ class DefaultLootTable implements LootTable, ItemSection {
                 if (key.equalsIgnoreCase("rolls")) {
                     rolls = section.getInt("rolls", 1);
                 } else if (key.equalsIgnoreCase("durability")) {
-                    itemDurability = (short) section.getInt("durability", -1);
+                    itemDamage = (short) section.getInt("damage", 0);
                 } else if (key.equalsIgnoreCase("id")) {
                     itemId = section.getString("id", "AIR");
                 } else if (key.equalsIgnoreCase("amount")) {
@@ -301,18 +301,25 @@ class DefaultLootTable implements LootTable, ItemSection {
 
         @Override
         public ItemStack getItem() {
-        	Material item = Material.valueOf(itemId);
+        	Material item = Material.getMaterial(itemId);
             if (item != null && itemAmount > 0) {
                 ItemStack result = new ItemStack(item, itemAmount);
-                if(itemDurability != -1)
+                ItemMeta meta = result.getItemMeta();
+                if(itemDamage != -1)
                 {
-                	ItemMeta meta = result.getItemMeta();
                 	if(meta instanceof Damageable)
                 	{
-                		((Damageable) meta).setDamage(itemDurability);
-                		result.setItemMeta(meta);
+                		((Damageable) meta).setDamage(itemDamage);
                 	}
                 }
+                else
+                {
+                	if(meta instanceof Damageable)
+                	{
+                		meta.setUnbreakable(true);
+                	}
+                }
+                result.setItemMeta(meta);
                 return result;
             }
             return new ItemStack(Material.AIR, 1);

--- a/src/main/java/com/dumptruckman/chestrestock/DefaultLootTable.java
+++ b/src/main/java/com/dumptruckman/chestrestock/DefaultLootTable.java
@@ -104,17 +104,10 @@ class DefaultLootTable implements LootTable, ItemSection {
         if (enchantment != null && enchantLevel != 0) {
             if (enchantLevel < 0) {
                 enchantLevel = -enchantLevel;
-                if (enchantSection.isSafe() && enchantLevel > enchantment.getMaxLevel()) {
-                    enchantLevel = enchantment.getMaxLevel();
-                }
                 enchantLevel = randGen.nextInt(enchantLevel) + 1;
                 Logging.finest("Using random enchant level for " + enchantment + ": " + enchantLevel);
             }
-            if (enchantSection.isSafe()) {
-                item.addEnchantment(enchantment, enchantLevel);
-            } else {
-                item.addUnsafeEnchantment(enchantment, enchantLevel);
-            }
+            item.addUnsafeEnchantment(enchantment, enchantLevel);
         }
         Logging.finest("Total weight of '" + enchantSection + "': " + enchantSection.getTotalWeight());
         float splitPicker = randGen.nextFloat() * enchantSection.getTotalWeight();
@@ -217,7 +210,6 @@ class DefaultLootTable implements LootTable, ItemSection {
         // Related to enchants
         protected String enchantName = "";
         protected int enchantLevel = 1;
-        protected boolean enchantSafe = true;
 
         DefaultLootSection(String name, ConfigurationSection section) {
             this.name = name;
@@ -242,8 +234,6 @@ class DefaultLootTable implements LootTable, ItemSection {
                     enchantName = section.getString("name", "");
                 } else if (key.equalsIgnoreCase("level")) {
                     enchantLevel = section.getInt("level", 1);
-                } else if (key.equalsIgnoreCase("safe")) {
-                    enchantSafe = section.getBoolean("safe", true);
                 } else {
                     try {
                         ConfigurationSection newSection = section.getConfigurationSection(key);
@@ -353,11 +343,6 @@ class DefaultLootTable implements LootTable, ItemSection {
         @Override
         public int getLevel() {
             return enchantLevel;
-        }
-
-        @Override
-        public boolean isSafe() {
-            return enchantSafe;
         }
 
         @Override

--- a/src/main/java/com/dumptruckman/chestrestock/DefaultLootTable.java
+++ b/src/main/java/com/dumptruckman/chestrestock/DefaultLootTable.java
@@ -220,7 +220,7 @@ class DefaultLootTable implements LootTable, ItemSection {
             for (String key : section.getKeys(false)) {
                 if (key.equalsIgnoreCase("rolls")) {
                     rolls = section.getInt("rolls", 1);
-                } else if (key.equalsIgnoreCase("durability")) {
+                } else if (key.equalsIgnoreCase("damage")) {
                     itemDamage = (short) section.getInt("damage", 0);
                 } else if (key.equalsIgnoreCase("id")) {
                     itemId = section.getString("id", "AIR");

--- a/src/main/java/com/dumptruckman/chestrestock/api/LootTable.java
+++ b/src/main/java/com/dumptruckman/chestrestock/api/LootTable.java
@@ -81,10 +81,5 @@ public interface LootTable {
          * @return The level of the enchantment.
          */
         int getLevel();
-
-        /**
-         * @return true if the enchantment should be applied safely.
-         */
-        boolean isSafe();
     }
 }

--- a/src/main/java/com/dumptruckman/chestrestock/util/InventoryTools.java
+++ b/src/main/java/com/dumptruckman/chestrestock/util/InventoryTools.java
@@ -13,7 +13,7 @@ public class InventoryTools {
      */
     public static ItemStack[] fillWithAir(ItemStack[] items) {
         for (int i = 0; i < items.length; i++) {
-            items[i] = new ItemStack(0);
+            items[i] = new ItemStack(Material.AIR);
         }
         return items;
     }

--- a/src/main/resources/loot_example.yml
+++ b/src/main/resources/loot_example.yml
@@ -9,25 +9,24 @@
 justaname:
   1: # This is just one of the sections that will be included in the loot. The number is meaningless. 
      # It serves to separate this loot section. This section lacks a chance so it always gives the listed item.
-    id: 278
+    id: DIAMOND_PICKAXE
     enchant: # enchant sections give the above items an enchantment. no chance is listed so it is 100% likely.
       name: silk_touch
+    durability: 60
   2: # Again, just a section of loot labeled with a meaningless number. This section has a 50% chance to be used.
     chance: .50
     split: true # split means that only one of the items below will be selected when section '2' is rolled.
     diamond: # this is just a name to represent a new section of loot. This section gives a diamond sword.
-      id: 276
+      id: DIAMOMD
     iron: # again just a name to represent the iron sword that is given by id: 267.
-      id: 267
+      id: IRON_INGOT
     wood: # a wooden sword with silk touch is the alternative to the diamond or iron sword above.
-      id: 268
+      id: WOODEN_SWORD
       enchant:
-        safe: false
         name: silk_touch
     enchant: # this enchant section will be applied to the above item twice.
       rolls: 2
       split: true # since it's split only one of the below enchant will be chosen on each of the 2 passes.
-      safe: false # this causes enchants to apply even if they're not valid for the given item.
       sharpness:
         name: damage_all
         level: -5 #the level of the enchant
@@ -44,13 +43,12 @@ justaname:
       chance: 5 # Due to the parent section being 'split: true' this is a weight rather than a percent chance.
                 # Weights are relative to the weight of all other sections. In this case, the chance of 5 means
                 # the weight is 5 times more than the chance of 1 in the below section.
-      id: 264
+      id: DIAMOND
     2:
       chance: 1
-      id: 266
+      id: GOLD_INGOT
       amount: 5
   4:
     chance: .10
-    id: 98
-    data: 2 # item data
+    id: BRICK
     amount: 20

--- a/src/main/resources/loot_example.yml
+++ b/src/main/resources/loot_example.yml
@@ -1,5 +1,5 @@
 # In this example, when the chest using loot_table 'justaname' restocks, there is a guaranteed diamond pickaxe with silk 
-# touch enchant, there is a 50% chance for: either a diamond/unbreakable wooden sword with up to 2 enchants (sharpness I-V, knockback I,
+# touch enchant, there is a 50% chance for: either a diamond/iron sword with up to 2 enchants (sharpness I-V, knockback I,
 # or fire aspect II) OR an unbreakable wood sword with silk touch, and a 10% chance for: a 20 stack of mossy stone blocks.
 # Further, section '3' is rolled 10 times, with a 10% chance of EITHER 1 diamond or 5 gold, but not both.  (And the
 # diamond is 5 times more likely!) There is also a 10% chance for 20 cracked stone brick (as indicated in '4').
@@ -7,49 +7,57 @@
 # such as chance, id, amount, damage, rolls, name, level, or enchant.  They should be unique headings though as if
 # they are the same, errors may occur.
 justaname:
-  1: # This is just one of the sections that will be included in the loot. The number is meaningless. 
-     # It serves to separate this loot section. This section lacks a chance so it always gives the listed item.
+  '1':
     id: DIAMOND_PICKAXE
-    enchant: # enchant sections give the above items an enchantment. no chance is listed so it is 100% likely.
+    enchant:
       name: silk_touch
     damage: 60
-  2: # Again, just a section of loot labeled with a meaningless number. This section has a 50% chance to be used.
-    chance: .50
-    split: true # split means that only one of the items below will be selected when section '2' is rolled.
-    diamond: # this is just a name to represent a new section of loot. This section gives a diamond sword.
-      id: DIAMOMD
-    iron: # again just a name to represent the iron sword that is given by id: 267.
-      id: IRON_INGOT
-    wood: # a wooden sword with silk touch is the alternative to the diamond or iron sword above.
+  '2':
+    chance: 0.5
+    split: true
+    diamond:
+      id: DIAMOND_SWORD
+      enchant:
+        rolls: 2
+        split: true
+        sharpness:
+          name: damage_all
+          level: -5
+        knockback:
+          name: knockback
+        fire:
+          name: fire_aspect
+          level: 2
+    iron:
+      id: IRON_SWORD
+      enchant:
+        rolls: 2
+        split: true
+        sharpness:
+          name: damage_all
+          level: -5
+        knockback:
+          name: knockback
+        fire:
+          name: fire_aspect
+          level: 2
+    wood:
       id: WOODEN_SWORD
-      damage: -1 # a damage value of -1 makes the item unbreakable
+      damage: -1
       enchant:
         name: silk_touch
-    enchant: # this enchant section will be applied to the above item twice.
-      rolls: 2
-      split: true # since it's split only one of the below enchant will be chosen on each of the 2 passes.
-      sharpness:
-        name: damage_all
-        level: -5 #the level of the enchant
-      knockback:
-        name: knockback
-      fire:
-        name: fire_aspect
-        level: 2
-  3: # This section is rolled 10 times and has a 10% chance to be selected.
+  '3':
     rolls: 10
-    chance: .10
-    split: true # This means that only one sub section will be chosen per roll.
-    1:
-      chance: 5 # Due to the parent section being 'split: true' this is a weight rather than a percent chance.
-                # Weights are relative to the weight of all other sections. In this case, the chance of 5 means
-                # the weight is 5 times more than the chance of 1 in the below section.
+    chance: 0.1
+    split: true
+    '1':
+      chance: 5
       id: DIAMOND
-    2:
+    '2':
       chance: 1
       id: GOLD_INGOT
       amount: 5
-  4:
-    chance: .10
+  '4':
+    chance: 0.1
     id: BRICK
     amount: 20

--- a/src/main/resources/loot_example.yml
+++ b/src/main/resources/loot_example.yml
@@ -1,10 +1,10 @@
 # In this example, when the chest using loot_table 'justaname' restocks, there is a guaranteed diamond pickaxe with silk 
-# touch enchant, there is a 50% chance for: either a diamond/iron sword with up to 2 enchants (sharpness I-V, knockback I,
-# or fire aspect II) OR a wood sword with silk touch, and a 10% chance for: a 20 stack of mossy stone blocks.
+# touch enchant, there is a 50% chance for: either a diamond/unbreakable wooden sword with up to 2 enchants (sharpness I-V, knockback I,
+# or fire aspect II) OR an unbreakable wood sword with silk touch, and a 10% chance for: a 20 stack of mossy stone blocks.
 # Further, section '3' is rolled 10 times, with a 10% chance of EITHER 1 diamond or 5 gold, but not both.  (And the
 # diamond is 5 times more likely!) There is also a 10% chance for 20 cracked stone brick (as indicated in '4').
 # An additional note, the numbers used as headings can be any number or word as long as they are not the key words
-# such as chance, id, amount, data, rolls, name, safe, level, or enchant.  They should be unique headings though as if
+# such as chance, id, amount, damage, rolls, name, level, or enchant.  They should be unique headings though as if
 # they are the same, errors may occur.
 justaname:
   1: # This is just one of the sections that will be included in the loot. The number is meaningless. 
@@ -12,7 +12,7 @@ justaname:
     id: DIAMOND_PICKAXE
     enchant: # enchant sections give the above items an enchantment. no chance is listed so it is 100% likely.
       name: silk_touch
-    durability: 60
+    damage: 60
   2: # Again, just a section of loot labeled with a meaningless number. This section has a 50% chance to be used.
     chance: .50
     split: true # split means that only one of the items below will be selected when section '2' is rolled.
@@ -22,6 +22,7 @@ justaname:
       id: IRON_INGOT
     wood: # a wooden sword with silk touch is the alternative to the diamond or iron sword above.
       id: WOODEN_SWORD
+      damage: -1 # a damage value of -1 makes the item unbreakable
       enchant:
         name: silk_touch
     enchant: # this enchant section will be applied to the above item twice.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: ChestRestock
 main: com.dumptruckman.chestrestock.ChestRestockPlugin
 version: maven-version-number
 author: dumptruckman
-api-version: 1.13
+api-version: 1.15
 softdepend: [Multiverse-Adventure]
 
 commands:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: ChestRestock
 main: com.dumptruckman.chestrestock.ChestRestockPlugin
 version: maven-version-number
 author: dumptruckman
+api-version: 1.13
 softdepend: [Multiverse-Adventure]
 
 commands:


### PR DESCRIPTION
As per your wishes, here's a pull request with a 1.13+ compatible version of the plugin. It's compiled against 1.15 has been tested with paper 1.15 and 1.14.4 with no issues.

[Compiled jar](https://github.com/dumptruckman/ChestRestock/files/4074796/ChestRestock-2.4.1.zip)

**Changes:**

The loot table system uses Spigot's Material system in order to identify items, rather than a numerical ID. 

Removed the data attribute as Spigot's support for creating itemstacks with raw Bytes as data has been deprecated. It should not be needed with the new ID system.

Added the damage attribute to allow people to make items with a certain durability. A damage of -1 makes the item unbreakable. 

Removed the safe enchantment attribute as it was somehow causing exceptions with the example loot config. My thought on this is that if a server admin is explicitly defining a loot table with unsafe enchantments, they probably intend to allow those. 

Updated the loot_example and loot_table files to reflect these changes. 

Thanks for your quick response to my issue and I hope this PR helps contribute to this amazing plugin 😄 